### PR TITLE
Fix anchorlinks using Hugo link render hooks

### DIFF
--- a/site/layouts/_default/_markup/render-heading.html
+++ b/site/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,4 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+  {{ .Text | safeHTML -}}
+  <a class="anchor" href="{{ .Page.Path }}/#{{ .Anchor }}">#</a>
+</h{{ .Level }}>

--- a/site/layouts/docs/single.html
+++ b/site/layouts/docs/single.html
@@ -31,7 +31,7 @@
 				{{ partial "sidebar/docs-toc.html" . }}
 			</nav>
 			{{ end -}}
-			{{ partial "main/headline-hash.html" .Content }}
+			{{ .Content | safeHTML }}
 			{{ if .Site.Params.editPage -}}
 				{{ partial "main/edit-page.html" . }}
 			{{ end -}}

--- a/site/layouts/partials/main/headline-hash.html
+++ b/site/layouts/partials/main/headline-hash.html
@@ -1,1 +1,0 @@
-{{ . | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1}<a href="#${2}" class="anchor" aria-hidden="true">#</a> ${3}` | safeHTML }}


### PR DESCRIPTION
Hugo link render hooks contain a variable reference to the current page. Using this we can prepend the current page's path to header anchor links. This fixes the issue where all anchor links for headers link back to the site homepage.

Tested locally with `just dev`.